### PR TITLE
SECURITY-1458: Harden NFS client

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -21,7 +21,7 @@
     /mnt/mount:
       src: "nfs-server.local:/export/path"
       fstype: "nfs4"
-      opts: "defaults,nosuid,ro"
+      opts: "defaults,nosuid,nodev,ro"
 ```
 
 #### Examples
@@ -36,14 +36,15 @@ include profile_nfs_client
 
 The following parameters are available in the `profile_nfs_client` class:
 
-* [`required_pkgs`](#required_pkgs)
+* [`masked_units`](#masked_units)
 * [`mountmap`](#mountmap)
+* [`required_pkgs`](#required_pkgs)
 
-##### <a name="required_pkgs"></a>`required_pkgs`
+##### <a name="masked_units"></a>`masked_units`
 
 Data type: `Array[ String ]`
 
-Packages that need to be installed for NFS mounts to work.
+List of systemctl units that should to be masked
 
 ##### <a name="mountmap"></a>`mountmap`
 
@@ -52,6 +53,12 @@ Data type: `Hash`
 mapping of NFS exports to local mount points
 
 Example hiera parameter:
+
+##### <a name="required_pkgs"></a>`required_pkgs`
+
+Data type: `Array[ String ]`
+
+Packages that need to be installed for NFS mounts to work.
 
 ## Defined types
 
@@ -66,8 +73,8 @@ Mount NFS export on a directory
 ```puppet
 profile_nfs_client::nfsmount { '/mnt/mount':
   src => 'nfs-server.local:/export/path',
-  fstype => 'nfs4',
-  opts => 'defaults,nosuid,ro'
+  fstype => 'nfs',
+  opts => 'defaults,nosuid,nodev,ro'
 }
 ```
 
@@ -91,7 +98,7 @@ Data type: `Optional[String]`
 
 Filesystem type to be mounted
 
-Default value: `'nfs4'`
+Default value: `'nfs'`
 
 ##### <a name="opts"></a>`opts`
 
@@ -99,5 +106,5 @@ Data type: `Optional[String]`
 
 Options for the filesystem mount
 
-Default value: `'defaults'`
+Default value: `'defaults,nosuid,nodev'`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,8 +3,8 @@
 #profile_nfs_client::mountmap:
 #  /mnt/mount:
 #    src: "nfs-server.local:/export/path"
-#    fstype: "nfs4"
-#    opts: "defaults,nosuid,ro"
+#    fstype: "nfs"
+#    opts: "defaults,nosuid,nodev,ro"
 
 profile_nfs_client::required_pkgs:
   - "nfs-utils"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,7 @@
+---
+profile_nfs_client::masked_units:
+  - "gssproxy.service"
+  - "rpc-gssd.service"
+  - "rpc-statd.service"
+  - "rpcbind.service"
+  - "rpcbind.socket"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 # @summary Configure NFS client and mounts
 #
-# @param required_pkgs
-#   Packages that need to be installed for NFS mounts to work.
-# 
+# @param masked_units
+#   List of systemctl units that should to be masked
+#
 # @param mountmap
 #   mapping of NFS exports to local mount points
 #
@@ -12,17 +12,30 @@
 #     /mnt/mount:
 #       src: "nfs-server.local:/export/path"
 #       fstype: "nfs4"
-#       opts: "defaults,nosuid,ro"
+#       opts: "defaults,nosuid,nodev,ro"
 # ```
 #
+# @param required_pkgs
+#   Packages that need to be installed for NFS mounts to work.
+# 
 # @example
 #   include profile_nfs_client
 class profile_nfs_client (
+  Array[ String ] $masked_units,
+  Hash            $mountmap,
   Array[ String ] $required_pkgs,
-  Hash $mountmap,
 ) {
 
   ensure_packages( $required_pkgs )
+
+  each($masked_units) | $unit |
+  {
+    exec { "mask_unit_${unit}":
+      command => "systemctl mask --now ${unit}",
+      unless  => "systemctl is-enabled ${unit} | grep -i masked",
+      path    => ['/bin', '/usr/bin', '/usr/sbin'],
+    }
+  }
 
   $mountmap.each | $k, $v | {
     profile_nfs_client::nfsmount { $k: * => $v }

--- a/manifests/nfsmount.pp
+++ b/manifests/nfsmount.pp
@@ -12,14 +12,14 @@
 # @example
 #   profile_nfs_client::nfsmount { '/mnt/mount': 
 #     src => 'nfs-server.local:/export/path', 
-#     fstype => 'nfs4',
-#     opts => 'defaults,nosuid,ro' 
+#     fstype => 'nfs',
+#     opts => 'defaults,nosuid,nodev,ro' 
 #   }
 #
 define profile_nfs_client::nfsmount (
   String $src,
-  Optional[String] $fstype = 'nfs4',
-  Optional[String] $opts = 'defaults',
+  Optional[String] $fstype = 'nfs',
+  Optional[String] $opts = 'defaults,nosuid,nodev',
 ) {
 
   # Resource defaults


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SECURITY-1458

Summary:
- Remove/mask unnecessary services/units configured by default
- Update defaults & examples to include `nodev` in mount options

This is being tested on `hli-login01`.